### PR TITLE
Add vitest WAT LSP validation for doc examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,17 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+  test-wat:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run test:wat
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -37,7 +37,10 @@ export default defineConfig({
       },
       expressiveCode: {
         shiki: {
-          langs: [{ ...watGrammar, name: 'wat', aliases: ['wast'] }],
+          langs: [
+            { ...watGrammar, name: 'wat', aliases: ['wast'] },
+            { ...watGrammar, name: 'wat-snippet', aliases: [] },
+          ],
         },
       },
       sidebar: [
@@ -69,7 +72,7 @@ export default defineConfig({
           items: [
             { label: 'Parametric', slug: 'stack/parametric' },
             { label: 'drop', slug: 'stack/drop' },
-            { label: 'tee', slug: 'stack/tee' },
+            { label: 'local.tee', slug: 'stack/tee' },
             { label: 'Memory & Data', slug: 'stack/memory-data' },
             { label: 'Traps', slug: 'stack/traps' },
           ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,8 @@
         "@astrojs/check": "^0.9.6",
         "@playwright/test": "^1.58.2",
         "oxfmt": "^0.28.0",
-        "oxlint": "^1.43.0"
+        "oxlint": "^1.43.0",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@astrojs/check": {
@@ -2595,6 +2596,13 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
@@ -2645,6 +2653,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2653,6 +2672,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2798,6 +2824,117 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@volar/kit": {
@@ -3081,6 +3218,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astring": {
@@ -3381,6 +3528,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -4254,6 +4411,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/expressive-code": {
       "version": "0.41.5",
@@ -6303,6 +6470,17 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/ofetch": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
@@ -6531,6 +6709,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -7293,6 +7478,13 @@
         "@types/hast": "^3.0.4"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -7364,10 +7556,24 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/state-local": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
       "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/stream-replace-string": {
@@ -7477,6 +7683,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -7510,6 +7723,16 @@
       "license": "MIT",
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -8079,6 +8302,84 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/volar-service-css": {
       "version": "0.0.68",
       "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.68.tgz",
@@ -8386,6 +8687,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/widest-line": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
@@ -8446,7 +8764,6 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "devOptional": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "astro": "astro",
     "test": "playwright test",
     "test:headed": "playwright test --headed",
+    "test:wat": "vitest run",
     "lint": "oxlint --deny-warnings",
     "lint:fix": "oxlint --fix",
     "format": "oxfmt --check .",
@@ -46,6 +47,7 @@
     "@astrojs/check": "^0.9.6",
     "@playwright/test": "^1.58.2",
     "oxfmt": "^0.28.0",
-    "oxlint": "^1.43.0"
+    "oxlint": "^1.43.0",
+    "vitest": "^4.0.18"
   }
 }

--- a/src/content/docs/instructions/module.md
+++ b/src/content/docs/instructions/module.md
@@ -9,7 +9,7 @@ Declares a WebAssembly module. Top-level container for all declarations.
 
 **Example:**
 
-```wat
+```wat-snippet
 (module $my_module
   ;; Module contents here
   (func ...)
@@ -202,7 +202,7 @@ Declares a function to be called automatically when the module is instantiated.
 
 **Example:**
 
-```wat
+```wat-snippet
 (module
   (func $init
     ;; Initialization code here

--- a/src/content/docs/ops/constants.md
+++ b/src/content/docs/ops/constants.md
@@ -18,7 +18,9 @@ Hex and floats:
 (module
   (func
     i32.const 0xFF
-    f64.const 3.14159)
+    drop
+    f64.const 3.14159
+    drop)
 )
 ```
 

--- a/src/content/docs/stack/tee.md
+++ b/src/content/docs/stack/tee.md
@@ -1,11 +1,9 @@
 ---
-title: tee (local.tee / global.tee)
-description: Store a value and keep it on the stack.
+title: local.tee
+description: Store a value into a local and keep it on the stack.
 ---
 
-`tee` variants write to a variable and also leave the value on the stack for further use.
-
-## local.tee
+`local.tee` writes to a local variable and also leaves the value on the stack for further use.
 
 ```wat
 (module
@@ -18,14 +16,17 @@ description: Store a value and keep it on the stack.
 )
 ```
 
-## global.tee
+There is no `global.tee` instruction. To set a global and keep the value on the stack, use `local.tee` into a temporary local and then `global.set`:
 
 ```wat
 (module
   (global $g (mut i32) (i32.const 0))
   (func (param $x i32) (result i32)
+    (local $tmp i32)
     local.get $x
-    global.tee $g      ;; store into global $g, keep value on stack
+    local.tee $tmp     ;; keep value on stack
+    global.set $g      ;; store copy into global $g (pops)
+    local.get $tmp     ;; push value back for further use
     i32.const 2
     i32.mul)
 )

--- a/src/content/docs/stack/traps.md
+++ b/src/content/docs/stack/traps.md
@@ -33,7 +33,8 @@ A trap is a runtime error that aborts execution. Common trap sources include:
   (memory 1)
   (func
     i32.const 70000      ;; > 64 KiB (one page)
-    i32.load             ;; will trap if address out of bounds
+    i32.load             ;; will trap: address out of bounds
+    drop
   )
 )
 ```

--- a/tests/wat-examples.test.mjs
+++ b/tests/wat-examples.test.mjs
@@ -1,0 +1,155 @@
+/**
+ * Tests all WAT module examples from documentation against the WAT LSP.
+ *
+ * Scans every markdown file in src/content/docs/ for ```wat code blocks
+ * that contain `(module`, runs each through the LSP, and reports diagnostics.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { glob } from 'node:fs/promises';
+import { Parser } from 'web-tree-sitter';
+import { describe, it, expect, beforeAll } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const DOCS_DIR = join(ROOT, 'src', 'content', 'docs');
+
+/**
+ * Known LSP false positives — valid WAT code that the LSP incorrectly flags
+ * due to missing support for proposals or type-checking bugs.
+ */
+const KNOWN_LSP_ISSUES = new Set([
+  // LSP type-checker doesn't handle `if` with `return`/`unreachable` correctly
+  'control/calls.md:9',
+  'control/return.md:9',
+  'control/unreachable-nop.md:10',
+  'stack/traps.md:17',
+  'stack/traps.md:45',
+  'reference-types.md:41',
+  // LSP doesn't support ref.null/ref.func syntax in various positions
+  'extensions/bulk-memory.md:29',
+  'extensions/extended-const.md:20',
+  'reference-types.md:16',
+  // LSP doesn't support multi-value block params, SIMD, typed func refs
+  'extensions/multi-value.md:19',
+  'extensions/simd.md:9',
+  'extensions/typed-func-refs.md:9',
+]);
+
+/**
+ * Extract all ```wat code blocks from a markdown string.
+ * Returns an array of { code, lineNumber } where lineNumber is 1-indexed.
+ */
+function extractWatBlocks(markdown) {
+  const blocks = [];
+  const lines = markdown.split('\n');
+
+  let inBlock = false;
+  let blockLines = [];
+  let blockStart = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (!inBlock && /^```wat\s*$/.test(line)) {
+      inBlock = true;
+      blockLines = [];
+      blockStart = i + 1;
+    } else if (inBlock && line.startsWith('```')) {
+      inBlock = false;
+      blocks.push({ code: blockLines.join('\n'), lineNumber: blockStart + 1 });
+    } else if (inBlock) {
+      blockLines.push(line);
+    }
+  }
+
+  return blocks;
+}
+
+function formatDiagnostics(diagnostics) {
+  return diagnostics
+    .map((d) => {
+      const severity = d.severity === 1 ? 'error' : d.severity === 2 ? 'warning' : 'info';
+      return `  ${severity} (${d.range.start.line + 1}:${d.range.start.character + 1}): ${d.message}`;
+    })
+    .join('\n');
+}
+
+// Collect all test cases before describing them
+async function collectExamples() {
+  const examples = [];
+  const mdFiles = [];
+
+  for await (const entry of glob('**/*.{md,mdx}', { cwd: DOCS_DIR })) {
+    mdFiles.push(entry);
+  }
+  mdFiles.sort();
+
+  for (const relPath of mdFiles) {
+    const absPath = join(DOCS_DIR, relPath);
+    const markdown = readFileSync(absPath, 'utf8');
+    const blocks = extractWatBlocks(markdown);
+    const moduleBlocks = blocks.filter((b) => b.code.includes('(module'));
+
+    for (const block of moduleBlocks) {
+      const displayPath = relative(join(ROOT, 'src', 'content', 'docs'), absPath);
+      const key = `${displayPath}:${block.lineNumber}`;
+      examples.push({
+        key,
+        code: block.code,
+        knownIssue: KNOWN_LSP_ISSUES.has(key),
+      });
+    }
+  }
+
+  return examples;
+}
+
+let lsp;
+
+async function initLSP() {
+  const distWasmDir = join(ROOT, 'node_modules', '@emnudge', 'wat-lsp', 'dist', 'wasm');
+  const treeSitterWasmPath = join(distWasmDir, 'tree-sitter.wasm');
+  const watLspWasmPath = join(distWasmDir, 'wat_lsp_rust_bg.wasm');
+
+  await Parser.init({
+    locateFile: (file) => {
+      if (file === 'tree-sitter.wasm') {
+        return `file://${treeSitterWasmPath}`;
+      }
+      return file;
+    },
+  });
+
+  const { default: initWasm, WatLSP } = await import('@emnudge/wat-lsp/wasm');
+  const wasmBuffer = readFileSync(watLspWasmPath);
+  await initWasm(wasmBuffer);
+
+  const instance = new WatLSP();
+  const success = await instance.initialize();
+  if (!success) {
+    throw new Error('Failed to initialize WAT LSP');
+  }
+  return instance;
+}
+
+const examples = await collectExamples();
+
+describe('WAT documentation examples', () => {
+  beforeAll(async () => {
+    lsp = await initLSP();
+  });
+
+  for (const example of examples) {
+    const testFn = example.knownIssue ? it.skip : it;
+    testFn(`${example.key} has no LSP errors`, () => {
+      lsp.parse(example.code);
+      const diagnostics = Array.from(lsp.provideDiagnostics());
+      const errors = diagnostics.filter((d) => d.severity === 1);
+
+      expect(errors, `LSP errors in ${example.key}:\n${formatDiagnostics(errors)}`).toHaveLength(0);
+    });
+  }
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    testTimeout: 30000,
+    include: ['tests/**/*.test.{js,mjs}'],
+  },
+});


### PR DESCRIPTION
## Summary
- Add vitest test that runs the WAT LSP against every editable `(module)` example in docs (44 pass, 12 skipped for known LSP limitations)
- Fix `global.tee` (not a real instruction) in tee.md with `local.tee` + `global.set` pattern
- Fix stack type mismatches in traps.md and constants.md
- Mark pseudo-code blocks in module.md as `wat-snippet` (syntax highlighted but not editable)
- Add `test-wat` CI job and `npm run test:wat` script

