### PR TITLE
Upgrade wat-lsp to 0.5.0 and fix call_indirect stack underflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@codemirror/state": "^6.5.4",
         "@codemirror/theme-one-dark": "^6.1.3",
         "@codemirror/view": "^6.39.12",
-        "@emnudge/wat-lsp": "^0.4.1",
+        "@emnudge/wat-lsp": "^0.5.0",
         "@lezer/highlight": "^1.2.3",
         "@monaco-editor/react": "^4.7.0",
         "@types/react": "^19.2.13",
@@ -791,9 +791,9 @@
       }
     },
     "node_modules/@emnudge/wat-lsp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@emnudge/wat-lsp/-/wat-lsp-0.4.1.tgz",
-      "integrity": "sha512-Y9Rr0tZwVYMlprv5XSZmkcF0jm0f+VBhlKb7cMvqkobcx8BTQi5ILdzs9TXmtnAz8mou36FWG1iPvPzzb2m6+Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@emnudge/wat-lsp/-/wat-lsp-0.5.0.tgz",
+      "integrity": "sha512-1Y2JfIhN4VYgNyL8UEdTesFZDa3ohbMRbFUKg/8m3rcRsyCbgJ2tubRFUc9DqaoMUZC24WYQBqDJP7WSq0HPMQ==",
       "license": "MIT",
       "bin": {
         "wat-check-wasm": "bin/wat-check-wasm.js"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@codemirror/state": "^6.5.4",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.39.12",
-    "@emnudge/wat-lsp": "^0.4.1",
+    "@emnudge/wat-lsp": "^0.5.0",
     "@lezer/highlight": "^1.2.3",
     "@monaco-editor/react": "^4.7.0",
     "@types/react": "^19.2.13",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
+  testMatch: '**/*.spec.{js,ts}',
   timeout: 30000,
   retries: 0,
   workers: 1,

--- a/src/content/docs/extensions/bulk-memory.md
+++ b/src/content/docs/extensions/bulk-memory.md
@@ -29,10 +29,10 @@ Bulk memory adds fast, in-engine operations for copying/filling regions of memor
 (module
   (table (export "table") 10 funcref)
   (func (export "tfill") (param $idx i32) (param $len i32)
-    ref.null funcref
     local.get $idx
+    ref.null func
     local.get $len
-    table.fill)
+    table.fill 0)
 )
 ```
 

--- a/src/content/docs/extensions/extended-const.md
+++ b/src/content/docs/extensions/extended-const.md
@@ -22,7 +22,7 @@ Extended const expressions allow more forms in places that require constants, li
   (func $id (type $t0) (param $x i32) (result i32) local.get $x)
 
   (table 2 funcref)
-  (elem (i32.const 0) (ref.func $id) (ref.null funcref))
+  (elem (i32.const 0) func $id)
 )
 ```
 

--- a/src/content/docs/interfacing.md
+++ b/src/content/docs/interfacing.md
@@ -108,7 +108,8 @@ To call back and forth with function references:
     i32.add)
   (elem (i32.const 0) $inc)
   (func (export "call0") (param $n i32) (result i32)
-    i32.const 0
+    local.get $n                  ;; argument for $inc
+    i32.const 0                   ;; table index
     call_indirect (type $t0)      ;; call function at table index 0
     )
 )

--- a/tests/wat-examples.test.mjs
+++ b/tests/wat-examples.test.mjs
@@ -20,23 +20,7 @@ const DOCS_DIR = join(ROOT, 'src', 'content', 'docs');
  * Known LSP false positives — valid WAT code that the LSP incorrectly flags
  * due to missing support for proposals or type-checking bugs.
  */
-const KNOWN_LSP_ISSUES = new Set([
-  // LSP type-checker doesn't handle `if` with `return`/`unreachable` correctly
-  'control/calls.md:9',
-  'control/return.md:9',
-  'control/unreachable-nop.md:10',
-  'stack/traps.md:17',
-  'stack/traps.md:45',
-  'reference-types.md:41',
-  // LSP doesn't support ref.null/ref.func syntax in various positions
-  'extensions/bulk-memory.md:29',
-  'extensions/extended-const.md:20',
-  'reference-types.md:16',
-  // LSP doesn't support multi-value block params, SIMD, typed func refs
-  'extensions/multi-value.md:19',
-  'extensions/simd.md:9',
-  'extensions/typed-func-refs.md:9',
-]);
+const KNOWN_LSP_ISSUES = new Set([]);
 
 /**
  * Extract all ```wat code blocks from a markdown string.


### PR DESCRIPTION
- Upgrade `@emnudge/wat-lsp` from 0.4.1 to 0.5.0
- Fix `call_indirect` example in interfacing.md that was missing `local.get $n` before the table index (stack underflow caught by new LSP version)