### PR TITLE
Fix editor newline handling and make containers scrollable

### DIFF
--- a/src/components/CodeMirrorEnhancer.tsx
+++ b/src/components/CodeMirrorEnhancer.tsx
@@ -474,7 +474,7 @@ async function enhanceCodeBlock(wrapper: HTMLElement) {
 
   if (lines.length > 0) {
     code = Array.from(lines)
-      .map((line) => line.textContent || '')
+      .map((line) => (line.textContent || '').replace(/^\n+|\n+$/g, ''))
       .join('\n');
   } else {
     const codeEl = wrapper.querySelector('code');
@@ -490,7 +490,7 @@ async function enhanceCodeBlock(wrapper: HTMLElement) {
     max-height: 400px;
     min-height: 120px;
     border-radius: 8px;
-    overflow: hidden;
+    overflow: auto;
     margin-block: 1rem;
   `;
 

--- a/src/components/MonacoEnhancer.tsx
+++ b/src/components/MonacoEnhancer.tsx
@@ -356,7 +356,7 @@ async function enhanceCodeBlock(wrapper: HTMLElement) {
 
   if (lines.length > 0) {
     code = Array.from(lines)
-      .map((line) => line.textContent || '')
+      .map((line) => (line.textContent || '').replace(/^\n+|\n+$/g, ''))
       .join('\n');
   } else {
     // Fallback: use code element
@@ -376,7 +376,7 @@ async function enhanceCodeBlock(wrapper: HTMLElement) {
   container.style.cssText = `
     height: ${height}px;
     border-radius: 8px;
-    overflow: hidden;
+    overflow: auto;
     margin-block: 1rem;
   `;
 


### PR DESCRIPTION
- Strip leading/trailing newlines from `.ec-line` textContent to prevent double newlines in editors
- Change editor container overflow from `hidden` to `auto` so long examples are scrollable