### PR TITLE
Clean up docs: s-expression syntax, fix bugs, trim boilerplate

### DIFF
--- a/src/components/CodeMirrorEnhancer.tsx
+++ b/src/components/CodeMirrorEnhancer.tsx
@@ -464,12 +464,15 @@ function shouldShowDiagnostics(): boolean {
   return !path.includes('/instructions/');
 }
 
-async function enhanceCodeBlock(wrapper: HTMLElement) {
-  if (wrapper.dataset.cmEnhanced) return;
-  wrapper.dataset.cmEnhanced = 'true';
+async function enhanceCodeBlock(pre: HTMLElement) {
+  const figure = pre.closest('figure');
+  const target = figure || pre;
 
-  // Extract code from ec-line divs
-  const lines = wrapper.querySelectorAll('.ec-line');
+  if (target.dataset.cmEnhanced) return;
+  target.dataset.cmEnhanced = 'true';
+
+  // Extract code from this specific pre's ec-line divs
+  const lines = pre.querySelectorAll('.ec-line');
   let code = '';
 
   if (lines.length > 0) {
@@ -477,7 +480,7 @@ async function enhanceCodeBlock(wrapper: HTMLElement) {
       .map((line) => (line.textContent || '').replace(/^\n+|\n+$/g, ''))
       .join('\n');
   } else {
-    const codeEl = wrapper.querySelector('code');
+    const codeEl = pre.querySelector('code');
     code = codeEl?.textContent || '';
   }
 
@@ -494,8 +497,9 @@ async function enhanceCodeBlock(wrapper: HTMLElement) {
     margin-block: 1rem;
   `;
 
-  // Replace the wrapper
-  wrapper.replaceWith(container);
+  // Replace only the figure, not the entire .expressive-code wrapper
+  // (the wrapper may contain sibling figures for other languages)
+  target.replaceWith(container);
 
   // Build extensions list
   const extensions = [
@@ -538,10 +542,7 @@ async function enhanceAllWatBlocks() {
   const pres = document.querySelectorAll('pre[data-language="wat"], pre[data-language="wast"]');
 
   for (const pre of pres) {
-    const wrapper = pre.closest('.expressive-code');
-    if (wrapper && !wrapper.hasAttribute('data-cm-enhanced')) {
-      await enhanceCodeBlock(wrapper as HTMLElement);
-    }
+    await enhanceCodeBlock(pre as HTMLElement);
   }
 }
 

--- a/src/content/docs/control/block.md
+++ b/src/content/docs/control/block.md
@@ -3,29 +3,20 @@ title: block
 description: Structured block with optional result type and label targets.
 ---
 
-`block` creates a new label and scope. It can optionally produce results.
+`block` creates a labeled scope. Branching to its label exits the block. It can optionally produce results.
 
 ```wat
 (module
   (func (param $n i32) (result i32)
     (block $out (result i32)
-      local.get $n
-      i32.const 0
-      i32.eq
-      br_if $out           ;; early-exit with the top-of-stack value (0/1)
-      i32.const 42         ;; normal path value
-    )
-  )
+      (br_if $out (i32.eqz (local.get $n)))
+      (i32.const 42)))
 )
 ```
 
-Notes:
+- Label names are optional — you can also target blocks by relative depth index.
+- A block with `(result ...)` must leave that typed value on the stack on all exits.
 
-- Label names are optional; you can target blocks by relative depth as well.
-- A block with a `(result ...)` must leave that value on the stack on all exits.
+## Instruction Reference
 
-Further reading:
-
-- [Control Flow Instructions](/instructions/control) - Complete reference for `block`, `loop`, `if`, `br`, `br_if`, etc.
-- Spec: [Blocks and result types](https://webassembly.github.io/spec/core/syntax/index.html)
-- Practice: browse exercises in [watlings](https://github.com/EmNudge/watlings/tree/main/exercises)
+- [Control Flow Instructions](/instructions/control) — `block`, `loop`, `if`, `br`, `br_if`

--- a/src/content/docs/control/br-table.md
+++ b/src/content/docs/control/br-table.md
@@ -3,7 +3,7 @@ title: br_table
 description: Multi-way branch (switch) over an index with a default.
 ---
 
-`br_table` pops an `i32` index and branches to one of several labels; out-of-range falls back to a default label. Useful for `switch`-like dispatch.
+`br_table` pops an `i32` index and branches to one of several labels. Out-of-range values fall through to a default label. Useful for `switch`-like dispatch.
 
 ```wat
 (module
@@ -12,31 +12,18 @@ description: Multi-way branch (switch) over an index with a default.
       (block $case2 (result i32)
         (block $case1 (result i32)
           (block $case0 (result i32)
-            local.get $tag
-            br_table $case0 $case1 $case2 $default
-          )
-          i32.const 10
-          br 3
-        )
-        i32.const 20
-        br 2
-      )
-      i32.const 30
-      br 1
-    )
-    ;; default
-    i32.const -1
-  )
+            (br_table $case0 $case1 $case2 $default
+              (local.get $tag)))
+          (return (i32.const 10)))
+        (return (i32.const 20)))
+      (return (i32.const 30)))
+    (i32.const -1))
 )
 ```
 
-Tips:
+- Label order matches indices 0..n-1, then a final default.
+- Each target must produce the block's result type(s).
 
-- Order of labels matches indices 0..n-1, then a final default.
-- Each target must produce the block’s result type(s).
+## Instruction Reference
 
-Further reading:
-
-- [Control Flow Instructions](/instructions/control) - Complete reference for `block`, `loop`, `if`, `br`, `br_if`, `br_table`, etc.
-- Spec: [br_table](https://webassembly.github.io/spec/core/syntax/index.html)
-- Practice: create small switch exercises in [watlings](https://github.com/EmNudge/watlings/tree/main/exercises)
+- [Control Flow Instructions](/instructions/control) — `block`, `loop`, `if`, `br`, `br_if`, `br_table`

--- a/src/content/docs/control/branching.md
+++ b/src/content/docs/control/branching.md
@@ -3,37 +3,30 @@ title: 'br & br_if'
 description: Structured branches to labeled blocks and loops.
 ---
 
-`br $label` performs an unconditional jump to the end of a `block` or to the top of a `loop`. `br_if` pops a condition and branches if non-zero.
+`br` performs an unconditional jump to the end of a `block` or to the top of a `loop`. `br_if` pops a condition and branches if non-zero.
 
 ```wat
 (module
   (func (param $n i32) (result i32)
     (block $exit (result i32)
-      local.get $n
-      i32.const 10
-      i32.gt_s
-      br_if $exit            ;; early return 1 for n > 10
-      i32.const 1
-      br $exit
-    )
-  )
+      (br_if $exit (i32.gt_s (local.get $n) (i32.const 10)))
+      (i32.const 1)
+      (br $exit)))
 )
 ```
 
-Relative labels:
+Relative labels — `br 0` targets the innermost label, `br 1` jumps one level out:
 
 ```wat
-;; br 0 targets the innermost label; br 1 jumps one level out, etc.
-(block (result i32)
-  (block (result i32)
-    i32.const 42
-    br 1            ;; exits the outer block, leaving 42 as its result
-  )
+(module
+  (func (result i32)
+    (block (result i32)
+      (block (result i32)
+        (i32.const 42)
+        (br 1))))
 )
 ```
 
-Further reading:
+## Instruction Reference
 
-- [Control Flow Instructions](/instructions/control) - Complete reference for `block`, `loop`, `if`, `br`, `br_if`, etc.
-- Spec: [Branching and label indices](https://webassembly.github.io/spec/core/syntax/index.html)
-- Practice: explore labeled blocks in [watlings](https://github.com/EmNudge/watlings/tree/main/exercises)
+- [Control Flow Instructions](/instructions/control) — `block`, `loop`, `if`, `br`, `br_if`

--- a/src/content/docs/control/calls.md
+++ b/src/content/docs/control/calls.md
@@ -3,39 +3,30 @@ title: 'call & call_indirect'
 description: Direct calls to known functions and indirect calls via tables.
 ---
 
-`call` invokes a known function by index/name. `call_indirect` dispatches through a table and type-checks a function signature at runtime.
+`call` invokes a function by index or name. `call_indirect` dispatches through a table and type-checks the signature at runtime.
 
 ```wat
 (module
   (type $t0 (func (param i32) (result i32)))
 
   (func $double (type $t0) (param $x i32) (result i32)
-    local.get $x
-    i32.const 2
-    i32.mul)
+    (i32.mul (local.get $x) (i32.const 2)))
 
   (func (export "use_call") (param $n i32) (result i32)
-    local.get $n
-    call $double)
+    (call $double (local.get $n)))
 
   (table 1 funcref)
   (elem (i32.const 0) $double)
 
   (func (export "use_call_indirect") (param $n i32) (result i32)
-    i32.const 0
-    local.get $n
-    call_indirect (type $t0))
+    (call_indirect (type $t0) (local.get $n) (i32.const 0)))
 )
 ```
 
-Notes:
+- For `call_indirect`, the last argument is the table element index. Preceding arguments are passed to the function.
+- The function at that index must match the declared `(type ...)`, or the call traps.
 
-- `call_indirect` takes a table index then the call arguments.
-- The function referenced must match the declared `(type ...)`, or the call traps.
+## Instruction Reference
 
-Further reading:
-
-- [Control Flow Instructions](/instructions/control) - Complete reference for `call`, `call_indirect`, `call_ref`, etc.
-- [Table Instructions](/instructions/table) - `table.get`, `table.set`, `table.grow`, etc.
-- Spec: [Call instructions, tables, and types](https://webassembly.github.io/spec/core/syntax/index.html)
-- Practice: function dispatch patterns in [watlings](https://github.com/EmNudge/watlings/tree/main/exercises)
+- [Control Flow Instructions](/instructions/control) — `call`, `call_indirect`, `call_ref`
+- [Table Instructions](/instructions/table) — `table.get`, `table.set`, `table.grow`

--- a/src/content/docs/control/if.md
+++ b/src/content/docs/control/if.md
@@ -3,30 +3,20 @@ title: 'if / else'
 description: Conditional execution with optional result values.
 ---
 
-`if` consumes a condition (`i32`: 0 = false, non-zero = true). Both branches must match result types if present.
+`if` consumes an `i32` condition (0 = false, non-zero = true). Both branches must match result types when present.
 
 ```wat
 (module
   (func (param $x i32) (result i32)
-    local.get $x
-    i32.const 0
-    i32.eq
-    if (result i32)
-      i32.const 1
-    else
-      i32.const 0
-    end
-  )
+    (if (result i32) (i32.eqz (local.get $x))
+      (then (i32.const 1))
+      (else (i32.const 0))))
 )
 ```
 
-Patterns:
+- Use `(result t)` to push a value from either branch.
+- Omit `else` when the block produces no result.
 
-- Branchless value computation: use `if (result t)` to push a value from either branch.
-- Omit `else` when not needed.
+## Instruction Reference
 
-Further reading:
-
-- [Control Flow Instructions](/instructions/control) - Complete reference for `block`, `loop`, `if`, `br`, `br_if`, etc.
-- Spec: [If and block typing](https://webassembly.github.io/spec/core/syntax/index.html)
-- Practice: conditionals in [watlings](https://github.com/EmNudge/watlings/tree/main/exercises)
+- [Control Flow Instructions](/instructions/control) — `block`, `loop`, `if`, `br`, `br_if`

--- a/src/content/docs/control/loop.md
+++ b/src/content/docs/control/loop.md
@@ -3,43 +3,25 @@ title: loop
 description: Repeat a block; branches target the top to continue.
 ---
 
-`loop` behaves like a labeled loop. Branching to its label jumps to the top (continue).
+Branching to a `loop` label jumps back to the top, like `continue` in other languages. Combine with an outer `block` for a clean break target.
 
 ```wat
 (module
   (func (param $n i32) (result i32)
     (local $acc i32)
-    i32.const 0
-    local.set $acc
-    (loop $again
-      local.get $n
-      i32.eqz
-      br_if $done
-
-      local.get $acc
-      i32.const 1
-      i32.add
-      local.set $acc
-
-      local.get $n
-      i32.const 1
-      i32.sub
-      local.set $n
-
-      br $again
-    )
-    (block $done)
-    local.get $acc)
+    (block $done
+      (loop $again
+        (br_if $done (i32.eqz (local.get $n)))
+        (local.set $acc (i32.add (local.get $acc) (i32.const 1)))
+        (local.set $n (i32.sub (local.get $n) (i32.const 1)))
+        (br $again)))
+    (local.get $acc))
 )
 ```
 
-Tips:
+- `br $again` jumps to the top of the loop.
+- `br_if $done` exits the outer block when `$n` reaches zero.
 
-- Use `br_if` to conditionally continue or exit.
-- Combine with an outer `block` label for a clean break target.
+## Instruction Reference
 
-Further reading:
-
-- [Control Flow Instructions](/instructions/control) - Complete reference for `block`, `loop`, `if`, `br`, `br_if`, etc.
-- Spec: [Control instructions](https://webassembly.github.io/spec/core/syntax/index.html)
-- Practice: related repetitions in [watlings](https://github.com/EmNudge/watlings/tree/main/exercises)
+- [Control Flow Instructions](/instructions/control) — `block`, `loop`, `br`, `br_if`

--- a/src/content/docs/control/return.md
+++ b/src/content/docs/control/return.md
@@ -8,28 +8,21 @@ description: Exit the current function, optionally pushing results.
 ```wat
 (module
   (func (param $x i32) (result i32)
-    local.get $x
-    i32.eqz
-    if
-      i32.const 0
-      return
-    end
-    i32.const 1
-  )
+    (if (i32.eqz (local.get $x))
+      (then (return (i32.const 0))))
+    (i32.const 1))
 )
 ```
 
 Multi-value:
 
 ```wat
-(func (param $a i32) (param $b i64) (result i32 i64)
-  local.get $a
-  local.get $b
-  return)
+(module
+  (func (param $a i32) (param $b i64) (result i32 i64)
+    (return (local.get $a) (local.get $b)))
+)
 ```
 
-Further reading:
+## Instruction Reference
 
-- [Control Flow Instructions](/instructions/control) - Complete reference for `return`, `return_call`, etc.
-- Spec: [Function results and return](https://webassembly.github.io/spec/core/syntax/index.html)
-- Practice: early-exit tasks in [watlings](https://github.com/EmNudge/watlings/tree/main/exercises)
+- [Control Flow Instructions](/instructions/control) — `return`, `return_call`

--- a/src/content/docs/control/select.md
+++ b/src/content/docs/control/select.md
@@ -3,27 +3,19 @@ title: select
 description: Choose between two stack values based on an i32 condition.
 ---
 
-`select` pops three values: `a`, `b`, and a condition `c`. It pushes `a` if `c != 0`, else `b`. Both `a` and `b` must share the same type.
+`select` pops three values — two candidates and a condition — and pushes the first if the condition is non-zero, otherwise the second. Both candidates must share the same type.
 
 ```wat
 (module
   (func (param $x i32) (param $y i32) (param $cond i32) (result i32)
-    local.get $x
-    local.get $y
-    local.get $cond
-    select)
+    (select (local.get $x) (local.get $y) (local.get $cond)))
 )
 ```
 
-Typed `select` (in newer specs) lets you annotate the result type; in WAT this may appear as `select (result i32)` depending on toolchain support.
+Typed `select` annotates the result type explicitly: `(select (result i32) ...)`.
 
-Use cases:
+Useful as a branchless min/max building block or compact conditional expression.
 
-- Branchless min/max building blocks.
-- Compact conditional expressions without `if`.
+## Instruction Reference
 
-Further reading:
-
-- [Parametric Instructions](/instructions/parametric) - Complete reference for `drop`, `select`
-- Spec: [Parametric select](https://webassembly.github.io/spec/core/syntax/index.html)
-- Practice: try conditional computations in [watlings](https://github.com/EmNudge/watlings/tree/main/exercises)
+- [Parametric Instructions](/instructions/parametric) — `drop`, `select`

--- a/src/content/docs/control/unreachable-nop.md
+++ b/src/content/docs/control/unreachable-nop.md
@@ -3,27 +3,18 @@ title: 'unreachable & nop'
 description: Trap immediately, or do nothing.
 ---
 
-- `unreachable` traps when executed. Helpful for asserting impossible states.
-- `nop` does nothing; occasionally useful as a placeholder.
+- `unreachable` — traps when executed. Useful for asserting impossible states.
+- `nop` — does nothing. Occasionally useful as a placeholder.
 
 ```wat
 (module
   (func (param $x i32)
-    local.get $x
-    i32.const 0
-    i32.lt_s
-    if
-      ;; negative not allowed
-      unreachable
-    else
-      nop
-    end
-  )
+    (if (i32.lt_s (local.get $x) (i32.const 0))
+      (then (unreachable))
+      (else (nop))))
 )
 ```
 
-Further reading:
+## Instruction Reference
 
-- [Control Flow Instructions](/instructions/control) - Complete reference for `unreachable`, `nop`, etc.
-- Spec: [Parametric and control instructions](https://webassembly.github.io/spec/core/syntax/index.html)
-- Practice: insert guards in [watlings](https://github.com/EmNudge/watlings/tree/main/exercises)
+- [Control Flow Instructions](/instructions/control) — `unreachable`, `nop`

--- a/src/content/docs/extensions/bulk-memory.md
+++ b/src/content/docs/extensions/bulk-memory.md
@@ -3,7 +3,7 @@ title: 'Bulk Memory Operations'
 description: 'Efficient copying and filling for memory and tables.'
 ---
 
-Bulk memory adds fast, in-engine operations for copying/filling regions of memory and tables.
+Bulk memory adds fast, in-engine operations for copying and filling regions of memory and tables.
 
 ## memory.copy and memory.fill
 
@@ -11,15 +11,9 @@ Bulk memory adds fast, in-engine operations for copying/filling regions of memor
 (module
   (memory (export "memory") 1)
   (func (export "copy") (param $dst i32) (param $src i32) (param $len i32)
-    local.get $dst
-    local.get $src
-    local.get $len
-    memory.copy)
+    (memory.copy (local.get $dst) (local.get $src) (local.get $len)))
   (func (export "fill") (param $dst i32) (param $value i32) (param $len i32)
-    local.get $dst
-    local.get $value
-    local.get $len
-    memory.fill)
+    (memory.fill (local.get $dst) (local.get $value) (local.get $len)))
 )
 ```
 
@@ -29,16 +23,11 @@ Bulk memory adds fast, in-engine operations for copying/filling regions of memor
 (module
   (table (export "table") 10 funcref)
   (func (export "tfill") (param $idx i32) (param $len i32)
-    local.get $idx
-    ref.null func
-    local.get $len
-    table.fill 0)
+    (table.fill 0 (local.get $idx) (ref.null func) (local.get $len)))
 )
 ```
 
-References:
+## Instruction Reference
 
-- [Memory Instructions](/instructions/memory) - `memory.copy`, `memory.fill`, `memory.init`, `data.drop`
-- [Table Instructions](/instructions/table) - `table.copy`, `table.fill`, `table.init`, `elem.drop`
-- Spec: https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: memory/table tasks in https://github.com/EmNudge/watlings
+- [Memory Instructions](/instructions/memory) — `memory.copy`, `memory.fill`, `memory.init`, `data.drop`
+- [Table Instructions](/instructions/table) — `table.copy`, `table.fill`, `table.init`, `elem.drop`

--- a/src/content/docs/extensions/exception-handling.md
+++ b/src/content/docs/extensions/exception-handling.md
@@ -7,30 +7,20 @@ Exception handling introduces `try`, `catch`, `throw`, and related constructs fo
 
 ```wat
 (module
-  (tag $e (param i32))  ;; exception tag carrying an i32
+  (tag $e (param i32))
 
   (func (export "mayThrow") (param $x i32) (result i32)
     (try (result i32)
       (do
-        local.get $x
-        i32.eqz
-        if
-          i32.const 1
-          throw $e
-        end
-        i32.const 0
-      )
+        (if (i32.eqz (local.get $x))
+          (then (throw $e (i32.const 1))))
+        (i32.const 0))
       (catch $e
-        ;; handle and return a value
-        i32.const -1
-      )
-    )
-  )
+        (drop)
+        (i32.const -1))))
 )
 ```
 
-References:
+## Instruction Reference
 
-- [Exception Instructions](/instructions/exceptions) - Complete reference for `throw`, `throw_ref`, `rethrow`, `tag`, `try_table`, `catch`, `catch_all`, etc.
-- Spec: https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: error control in https://github.com/EmNudge/watlings
+- [Exception Instructions](/instructions/exceptions) — `throw`, `throw_ref`, `rethrow`, `tag`, `try_table`, `catch`, `catch_all`

--- a/src/content/docs/extensions/extended-const.md
+++ b/src/content/docs/extensions/extended-const.md
@@ -19,17 +19,16 @@ Extended const expressions allow more forms in places that require constants, li
 ```wat
 (module
   (type $t0 (func (param i32) (result i32)))
-  (func $id (type $t0) (param $x i32) (result i32) local.get $x)
+  (func $id (type $t0) (param $x i32) (result i32)
+    (local.get $x))
 
   (table 2 funcref)
   (elem (i32.const 0) func $id)
 )
 ```
 
-References:
+## Instruction Reference
 
-- [Local & Global Instructions](/instructions/local-global) - `global.get`
-- [Reference Instructions](/instructions/reference) - `ref.func`, `ref.null`
-- [Module Structure](/instructions/module) - `global`, `elem`, `data`
-- Spec (syntax): https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: globals/tables in https://github.com/EmNudge/watlings
+- [Local & Global Instructions](/instructions/local-global) — `global.get`
+- [Reference Instructions](/instructions/reference) — `ref.func`, `ref.null`
+- [Module Structure](/instructions/module) — `global`, `elem`, `data`

--- a/src/content/docs/extensions/js-bigint-i64.md
+++ b/src/content/docs/extensions/js-bigint-i64.md
@@ -8,26 +8,20 @@ Modern JS engines map Wasm `i64` to JavaScript `BigInt`. You can pass `BigInt` v
 ```wat
 (module
   (func (export "inc64") (param $x i64) (result i64)
-    local.get $x
-    i64.const 1
-    i64.add)
+    (i64.add (local.get $x) (i64.const 1)))
 )
 ```
 
+From JS, pass and receive `BigInt`:
+
 ```javascript
 const { instance } = await WebAssembly.instantiate(wasmBytes);
-// BigInt in, BigInt out:
 console.log(instance.exports.inc64(41n)); // 42n
 ```
-
-Notes:
 
 - Non-BigInt JS numbers are not accepted for `i64` parameters.
 - Passing `BigInt` to non-`i64` params will throw.
 
-References:
+## Instruction Reference
 
-- [i64 Instructions](/instructions/i64) - Complete reference for all i64 operations
-- [Type Names](/instructions/types) - `i64` type reference
-- Spec types overview: https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: i64 exercises in https://github.com/EmNudge/watlings
+- [i64 Instructions](/instructions/i64)

--- a/src/content/docs/extensions/multi-value.md
+++ b/src/content/docs/extensions/multi-value.md
@@ -8,8 +8,8 @@ description: 'Functions and blocks can produce multiple results; blocks can take
 ```wat
 (module
   (func (export "pair") (param $x i32) (result i32 i32)
-    local.get $x
-    i32.const 1)
+    (local.get $x)
+    (i32.const 1))
 )
 ```
 
@@ -18,19 +18,14 @@ description: 'Functions and blocks can produce multiple results; blocks can take
 ```wat
 (module
   (func (param $a i32) (param $b i32) (result i32)
-    local.get $a
-    local.get $b
+    (local.get $a)
+    (local.get $b)
     (block (param i32 i32) (result i32)
-      ;; stack has: a b
-      i32.add            ;; consume both, push sum
-    )
-  )
+      (i32.add)))
 )
 ```
 
-References:
+## Instruction Reference
 
-- [Module Structure](/instructions/module) - `func`, `param`, `result`
-- [Control Flow Instructions](/instructions/control) - `block`, `loop`, `if` with multiple results
-- Spec: https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: multi-result functions in https://github.com/EmNudge/watlings
+- [Module Structure](/instructions/module) — `func`, `param`, `result`
+- [Control Flow Instructions](/instructions/control) — `block`, `loop`, `if` with multiple results

--- a/src/content/docs/extensions/mutable-globals.md
+++ b/src/content/docs/extensions/mutable-globals.md
@@ -11,6 +11,8 @@ description: 'Share and modify mutable globals between JS and Wasm.'
 )
 ```
 
+From JS, read and write via `.value`:
+
 ```javascript
 const { instance } = await WebAssembly.instantiate(wasmBytes);
 console.log(instance.exports.counter.value); // 0
@@ -24,12 +26,11 @@ console.log(instance.exports.counter.value); // 5
 (module
   (import "env" "g" (global $g (mut i32)))
   (func (export "inc")
-    global.get $g
-    i32.const 1
-    i32.add
-    global.set $g)
+    (global.set $g (i32.add (global.get $g) (i32.const 1))))
 )
 ```
+
+Create a `WebAssembly.Global` on the JS side and pass it as an import:
 
 ```javascript
 const g = new WebAssembly.Global({ value: 'i32', mutable: true }, 0);
@@ -38,9 +39,7 @@ instance.exports.inc();
 console.log(g.value); // 1
 ```
 
-References:
+## Instruction Reference
 
-- [Local & Global Instructions](/instructions/local-global) - `global.get`, `global.set`
-- [Module Structure](/instructions/module) - `global`, `import`, `export`
-- Spec: https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: globals in https://github.com/EmNudge/watlings
+- [Local & Global Instructions](/instructions/local-global) — `global.get`, `global.set`
+- [Module Structure](/instructions/module) — `global`, `import`, `export`

--- a/src/content/docs/extensions/nontrapping-f2i.md
+++ b/src/content/docs/extensions/nontrapping-f2i.md
@@ -3,24 +3,17 @@ title: 'Non-trapping float-to-int'
 description: 'Saturating conversions from floats to integers that do not trap.'
 ---
 
-Instead of trapping on overflow/NaN, these instructions clamp to min/max and convert NaN to 0.
+Instead of trapping on overflow or NaN, these instructions clamp to min/max and convert NaN to 0.
 
 ```wat
 (module
   (func (export "sat") (param $x f32) (result i32)
-    local.get $x
-    i32.trunc_sat_f32_s)
+    (i32.trunc_sat_f32_s (local.get $x)))
 )
 ```
 
-Variations include:
+All variants: `i32.trunc_sat_f32_s/u`, `i32.trunc_sat_f64_s/u`, `i64.trunc_sat_f32_s/u`, `i64.trunc_sat_f64_s/u`.
 
-- `i32.trunc_sat_f32_s`, `i32.trunc_sat_f32_u`, `i32.trunc_sat_f64_s`, `i32.trunc_sat_f64_u`
-- `i64.trunc_sat_f32_s`, `i64.trunc_sat_f32_u`, `i64.trunc_sat_f64_s`, `i64.trunc_sat_f64_u`
+## Instruction Reference
 
-References:
-
-- [i32 Instructions](/instructions/i32) - `i32.trunc_sat_f32_s`, `i32.trunc_sat_f32_u`, `i32.trunc_sat_f64_s`, `i32.trunc_sat_f64_u`
-- [i64 Instructions](/instructions/i64) - `i64.trunc_sat_f32_s`, `i64.trunc_sat_f32_u`, `i64.trunc_sat_f64_s`, `i64.trunc_sat_f64_u`
-- Spec: https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: numeric conversions in https://github.com/EmNudge/watlings
+- [i32 Instructions](/instructions/i32), [i64 Instructions](/instructions/i64)

--- a/src/content/docs/extensions/reference-types.md
+++ b/src/content/docs/extensions/reference-types.md
@@ -3,15 +3,12 @@ title: 'Reference Types (externref)'
 description: 'Hold references to host objects and use function references.'
 ---
 
-This extension lets Wasm store references to host objects (`externref`) and introduces more flexible function references. See the Language page for fundamentals.
+This extension lets Wasm store references to host objects (`externref`) and introduces more flexible function references.
 
-- Start here: [/reference-types/](/reference-types/)
-- Use with tables and `call_indirect` for dynamic dispatch.
+See the [Reference Types](/reference-types/) page for fundamentals. Use with tables and `call_indirect` for dynamic dispatch.
 
-References:
+## Instruction Reference
 
-- [Reference Instructions](/instructions/reference) - `ref.null`, `ref.func`, `ref.is_null`, etc.
-- [Table Instructions](/instructions/table) - `table.get`, `table.set`, etc.
-- [Type Names](/instructions/types) - `funcref`, `externref`, etc.
-- Spec: https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: function tables in https://github.com/EmNudge/watlings
+- [Reference Instructions](/instructions/reference) — `ref.null`, `ref.func`, `ref.is_null`
+- [Table Instructions](/instructions/table) — `table.get`, `table.set`
+- [Type Names](/instructions/types) — `funcref`, `externref`

--- a/src/content/docs/extensions/sign-extension.md
+++ b/src/content/docs/extensions/sign-extension.md
@@ -8,22 +8,17 @@ These operators widen integers while preserving the sign of the smaller type.
 ```wat
 (module
   (func (export "ext8") (param $x i32) (result i32)
-    local.get $x
-    i32.extend8_s)      ;; sign-extend low 8 bits to 32-bit
+    (i32.extend8_s (local.get $x)))
 
   (func (export "ext16") (param $x i32) (result i32)
-    local.get $x
-    i32.extend16_s)
+    (i32.extend16_s (local.get $x)))
 
   (func (export "ext32") (param $x i64) (result i64)
-    local.get $x
-    i64.extend32_s)
+    (i64.extend32_s (local.get $x)))
 )
 ```
 
-References:
+## Instruction Reference
 
-- [i32 Instructions](/instructions/i32) - `i32.extend8_s`, `i32.extend16_s`
-- [i64 Instructions](/instructions/i64) - `i64.extend8_s`, `i64.extend16_s`, `i64.extend32_s`
-- Spec: https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: integer ops in https://github.com/EmNudge/watlings
+- [i32 Instructions](/instructions/i32) — `i32.extend8_s`, `i32.extend16_s`
+- [i64 Instructions](/instructions/i64) — `i64.extend8_s`, `i64.extend16_s`, `i64.extend32_s`

--- a/src/content/docs/extensions/simd.md
+++ b/src/content/docs/extensions/simd.md
@@ -8,19 +8,13 @@ SIMD enables lane-wise parallel operations on 128-bit vectors.
 ```wat
 (module
   (func (export "add4") (param $x v128) (param $y v128) (result v128)
-    local.get $x
-    local.get $y
-    i32x4.add)
+    (i32x4.add (local.get $x) (local.get $y)))
 )
 ```
 
-Notes:
-
 - Construct vectors with `v128.const`, `i32x4.splat`, etc.
-- Load/store with `v128.load` / `v128.store`. Requires appropriate alignment/feature support.
+- Load/store with `v128.load` / `v128.store`.
 
-References:
+## Instruction Reference
 
-- [SIMD Instructions](/instructions/simd) - Complete reference for all v128, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2 operations
-- Spec: https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: numeric fundamentals in https://github.com/EmNudge/watlings
+- [SIMD Instructions](/instructions/simd) — all v128, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2 operations

--- a/src/content/docs/extensions/tail-call.md
+++ b/src/content/docs/extensions/tail-call.md
@@ -3,26 +3,17 @@ title: 'Tail Calls'
 description: 'return_call and return_call_indirect for optimized recursion.'
 ---
 
-Tail calls allow a function to transfer control to another function as its final action without growing the stack.
+Tail calls let a function transfer control to another function as its final action without growing the stack.
 
 ```wat
 (module
   (func $f (param $n i32) (result i32)
-    local.get $n
-    i32.eqz
-    if (result i32)
-      i32.const 0
-    else
-      local.get $n
-      i32.const 1
-      i32.sub
-      return_call $f
-    end)
+    (if (result i32) (i32.eqz (local.get $n))
+      (then (i32.const 0))
+      (else (return_call $f (i32.sub (local.get $n) (i32.const 1))))))
 )
 ```
 
-References:
+## Instruction Reference
 
-- [Control Flow Instructions](/instructions/control) - `return_call`, `call`, `call_indirect`, etc.
-- Spec: https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: recursion fundamentals in https://github.com/EmNudge/watlings
+- [Control Flow Instructions](/instructions/control) — `return_call`, `return_call_indirect`

--- a/src/content/docs/extensions/typed-func-refs.md
+++ b/src/content/docs/extensions/typed-func-refs.md
@@ -9,24 +9,17 @@ Typed function references make function refs carry specific types and enable `ca
 (module
   (type $t0 (func (param i32) (result i32)))
   (func $inc (type $t0) (param $x i32) (result i32)
-    local.get $x
-    i32.const 1
-    i32.add)
+    (i32.add (local.get $x) (i32.const 1)))
+
   (table 1 funcref)
   (elem (i32.const 0) $inc)
 
-  (func (export "dispatch") (param $i i32) (param $x i32) (result i32)
-    local.get $i
-    ref.func $inc
-    drop                  ;; example only; normally fetch from table
-    local.get $x
-    call_ref (type $t0))
+  (func (export "dispatch") (param $x i32) (result i32)
+    (call_ref (type $t0) (local.get $x) (ref.func $inc)))
 )
 ```
 
-References:
+## Instruction Reference
 
-- [Control Flow Instructions](/instructions/control) - `call_ref`, `return_call_ref`, `br_on_null`, `br_on_non_null`
-- [Reference Instructions](/instructions/reference) - `ref.func`, `ref.null`, `ref.is_null`, `ref.as_non_null`
-- Spec: https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: dispatch patterns in https://github.com/EmNudge/watlings
+- [Control Flow Instructions](/instructions/control) — `call_ref`, `return_call_ref`, `br_on_null`, `br_on_non_null`
+- [Reference Instructions](/instructions/reference) — `ref.func`, `ref.null`, `ref.is_null`, `ref.as_non_null`

--- a/src/content/docs/extensions/wasm-gc.md
+++ b/src/content/docs/extensions/wasm-gc.md
@@ -3,22 +3,20 @@ title: 'Garbage Collection (WasmGC)'
 description: 'Low-level primitives for managed structs/arrays to support GC languages.'
 ---
 
-WasmGC provides reference-typed objects (structs, arrays) that engines can manage with garbage collection. This enables efficient runtimes for languages like Kotlin/Java/Dart.
+WasmGC provides reference-typed objects (structs, arrays) that engines can manage with garbage collection. This enables efficient runtimes for languages like Kotlin, Java, and Dart.
 
-Concepts:
+Key concepts:
 
 - Reference-typed heaps managed by the VM.
 - Typed `struct` and `array` values.
 - Interop with host via `externref`.
 
-Because syntax and support are evolving, check your toolchain’s documentation for exact WAT forms. Explore language toolchains that target WasmGC for real-world usage.
+Syntax and support are still evolving — check your toolchain's documentation for exact WAT forms.
 
-References:
+## Instruction Reference
 
-- [GC Types](/instructions/gc-types) - `sub`, `final`, `rec`, `field`, `struct`, `array`, etc.
-- [GC Struct](/instructions/gc-struct) - `struct.new`, `struct.get`, `struct.set`, etc.
-- [GC Array](/instructions/gc-array) - `array.new`, `array.get`, `array.set`, `array.len`, etc.
-- [GC i31](/instructions/gc-i31) - `ref.i31`, `i31.get_s`, `i31.get_u`
-- [GC Casts](/instructions/gc-casts) - `ref.test`, `ref.cast`, `br_on_cast`, etc.
-- Spec overview (evolving proposals): https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: higher-level runtimes often showcased outside of watlings, but see https://github.com/EmNudge/watlings for fundamentals
+- [GC Types](/instructions/gc-types) — `sub`, `final`, `rec`, `field`, `struct`, `array`
+- [GC Struct](/instructions/gc-struct) — `struct.new`, `struct.get`, `struct.set`
+- [GC Array](/instructions/gc-array) — `array.new`, `array.get`, `array.set`, `array.len`
+- [GC i31](/instructions/gc-i31) — `ref.i31`, `i31.get_s`, `i31.get_u`
+- [GC Casts](/instructions/gc-casts) — `ref.test`, `ref.cast`, `br_on_cast`

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -26,16 +26,11 @@ hero:
       variant: minimal
 ---
 
-WAT is the human-readable text representation of WebAssembly modules. It mirrors the binary format closely while remaining friendly enough to read, write, and learn from.
+WAT is the human-readable text format of WebAssembly. It mirrors the binary format closely while being friendly enough to read, write, and learn from.
 
-This site focuses on:
+- **[Types](/types/)** — the values functions accept and return
+- **[Operators](/operators/)** — core instructions you'll use every day
+- **[Interfacing](/interfacing/)** — importing functions, exporting APIs, and sharing memory with hosts
+- **[Instruction Reference](/instructions/i32/)** — complete docs for all WebAssembly instructions
 
-- Types: the values functions accept and return
-- Operators: core instructions you'll use every day
-- Interfacing: importing functions, exporting APIs, and sharing memory with hosts
-- Instruction Reference: complete documentation for all WebAssembly instructions
-
-Further reading:
-
-- Learn by doing with the Watlings exercises: [watlings](https://github.com/EmNudge/watlings)
-- Consult the authoritative spec for exact grammar and semantics: [WebAssembly spec (Structure → Syntax)](https://webassembly.github.io/spec/core/syntax/index.html)
+Further reading: [Watlings exercises](https://github.com/EmNudge/watlings) | [WebAssembly spec](https://webassembly.github.io/spec/core/syntax/index.html)

--- a/src/content/docs/interfacing.md
+++ b/src/content/docs/interfacing.md
@@ -5,35 +5,30 @@ description: Import functions, export APIs, and share memory to call WAT modules
 
 Most real programs talk to a host (like JavaScript) via imports/exports and linear memory.
 
-For authoritative syntax and semantics, see the [WebAssembly spec — Structure → Modules, Imports, Exports, Memories](https://webassembly.github.io/spec/core/syntax/index.html).
-
 ## Imports and exports
 
 ```wat
 (module
-  ;; Import a function `env.log: (i32) -> ()`
+  ;; Import a function: env.log(i32) -> ()
   (import "env" "log" (func $log (param i32)))
 
-  ;; Export a function and a memory
-  (memory $mem 1)                      ;; 1 page = 64 KiB
+  ;; Declare and export a memory
+  (memory $mem 1)
   (export "memory" (memory $mem))
 
-  (func $add (param $a i32) (param $b i32) (result i32)
-    local.get $a
-    local.get $b
-    i32.add)
-  (export "add" (func $add))
+  ;; Export a function
+  (func $add (export "add") (param $a i32) (param $b i32) (result i32)
+    (i32.add (local.get $a) (local.get $b)))
 )
 ```
 
-- Imports bring host functionality into the module, namespaced by module string (e.g., `"env"`).
-- Exports make module items available to the host by name.
+- **Imports** bring host functionality in, namespaced by module string (e.g. `"env"`).
+- **Exports** make module items available to the host by name.
 
 ## Calling from JavaScript
 
 ```javascript
-// Assume you have compiled WAT to .wasm bytes (e.g., with wasm-tools or wat2wasm).
-const wasmBytes = await fetch('/path/to/module.wasm').then((r) => r.arrayBuffer());
+const wasmBytes = await fetch('/module.wasm').then((r) => r.arrayBuffer());
 
 const imports = {
   env: {
@@ -45,26 +40,23 @@ const { instance } = await WebAssembly.instantiate(wasmBytes, imports);
 console.log(instance.exports.add(20, 22)); // 42
 ```
 
-- JS import object shape matches your `(import "module" "name" ...)` declarations.
-- Exported functions are regular callable JS functions. Memories and tables are objects.
+- The JS import object shape must match your `(import ...)` declarations.
+- Exported functions are callable JS functions. Memories and tables are objects.
 
 ## Working with linear memory
 
-You can share bytes via a `memory` export. From JS, view it as a typed array.
+Share bytes via a `memory` export. From JS, view it as a typed array.
 
 ```wat
 (module
-  (memory $mem 1)
-  (export "memory" (memory $mem))
+  (memory (export "memory") 1)
 
-  ;; Write a byte at an offset
-  (func $write_byte (param $offset i32) (param $value i32)
-    local.get $value
-    local.get $offset
-    i32.store8)                 ;; store 8-bit at memory[offset]
-  (export "write_byte" (func $write_byte))
+  (func (export "write_byte") (param $offset i32) (param $value i32)
+    (i32.store8 (local.get $offset) (local.get $value)))
 )
 ```
+
+Then from JS, view the memory as a typed array:
 
 ```javascript
 const { instance } = await WebAssembly.instantiate(wasmBytes);
@@ -75,14 +67,11 @@ instance.exports.write_byte(1, 0x69); // 'i'
 console.log(new TextDecoder().decode(mem.subarray(0, 2))); // "Hi"
 ```
 
-Notes:
-
-- Memory is grown in 64 KiB pages; you can allow growth with `(memory min max?)`. If you grow, the underlying `ArrayBuffer` can change; refresh your typed array views after growth.
-- Loads/stores are typed instructions: `i32.store`, `i32.store8`, `i32.load`, etc. Alignment hints are optional in text format.
+Memory is grown in 64 KiB pages. You can allow growth with `(memory min max)`. After growth the underlying `ArrayBuffer` can change — refresh your typed array views.
 
 ## Passing strings
 
-Wasm deals in bytes, so strings are a convention: encode to bytes on the host, pass a pointer/length to Wasm, and decode on the other side. A simple pattern from JS:
+Wasm deals in bytes, so strings are a convention: encode to bytes on the host, pass a pointer and length to Wasm, and decode on the other side.
 
 ```javascript
 function writeString(memU8, offset, str) {
@@ -92,40 +81,27 @@ function writeString(memU8, offset, str) {
 }
 ```
 
-On the Wasm side, consume bytes starting at the offset for the given length.
-
 ## Tables and function references
-
-To call back and forth with function references:
 
 ```wat
 (module
-  (table 1 funcref)
   (type $t0 (func (param i32) (result i32)))
   (func $inc (type $t0) (param $x i32) (result i32)
-    local.get $x
-    i32.const 1
-    i32.add)
+    (i32.add (local.get $x) (i32.const 1)))
+
+  (table 1 funcref)
   (elem (i32.const 0) $inc)
+
   (func (export "call0") (param $n i32) (result i32)
-    local.get $n                  ;; argument for $inc
-    i32.const 0                   ;; table index
-    call_indirect (type $t0)      ;; call function at table index 0
-    )
+    (call_indirect (type $t0) (local.get $n) (i32.const 0)))
 )
 ```
 
-From JS, you can also supply host funcs via imports and store them in tables if desired.
+The last argument to `call_indirect` is the table element index; preceding arguments are passed to the function.
 
 ## Instruction Reference
 
-For complete instruction documentation:
-
-- [Module Structure](/instructions/module) - `module`, `func`, `import`, `export`, `memory`, `table`, etc.
-- [Memory Instructions](/instructions/memory) - `memory.size`, `memory.grow`, etc.
-- [Table Instructions](/instructions/table) - `table.get`, `table.set`, `table.grow`, etc.
-- [Control Flow Instructions](/instructions/control) - `call`, `call_indirect`, etc.
-
-## Tooling note
-
-This site assumes you're working in WAT. For learn-by-doing exercises and a `wasm-tools`-based workflow, try [watlings](https://github.com/EmNudge/watlings). Its scripts rely on `wasm-tools parse` to assemble WAT to Wasm.
+- [Module Structure](/instructions/module) — `module`, `func`, `import`, `export`, `memory`, `table`
+- [Memory Instructions](/instructions/memory) — `memory.size`, `memory.grow`
+- [Table Instructions](/instructions/table) — `table.get`, `table.set`, `table.grow`
+- [Control Flow](/instructions/control) — `call`, `call_indirect`

--- a/src/content/docs/operators.md
+++ b/src/content/docs/operators.md
@@ -3,135 +3,117 @@ title: Operators
 description: The essential WAT instructions for arithmetic, comparison, locals, and control flow.
 ---
 
-At its core, WebAssembly is a stack machine. Most instructions pop their operands from the stack and push results back. Below are the operators you’ll reach for most often.
-
-For full instruction lists and exact rules, see the [WebAssembly spec — Structure → Instructions](https://webassembly.github.io/spec/core/syntax/index.html).
+WebAssembly is a stack machine. Most instructions pop operands from the stack and push results back.
 
 ## Reading and writing locals
 
 ```wat
-(func (param $a i32) (param $b i32) (result i32)
-  (local $tmp i32)
-  local.get $a       ;; push a
-  local.get $b       ;; push b
-  i32.add            ;; pop a,b -> push (a+b)
-  local.set $tmp     ;; store result into $tmp (pops)
-  local.get $tmp     ;; push $tmp again
+(module
+  (func (param $a i32) (param $b i32) (result i32)
+    (local $tmp i32)
+    (local.set $tmp (i32.add (local.get $a) (local.get $b)))
+    (local.get $tmp))
 )
 ```
 
-- `local.get $x`: push the value of local `$x`.
-- `local.set $x`: pop and store into local `$x`.
-- `local.tee $x`: like set, but also re-pushes the stored value.
+- `local.get $x` — push the value of local `$x`.
+- `local.set $x` — pop and store into local `$x`.
+- `local.tee $x` — like set, but also keeps the value on the stack.
 
 ## Numeric arithmetic
 
-Integer arithmetic (wraps on overflow):
+Integer arithmetic wraps on overflow:
 
 ```wat
-(func (param $x i32) (param $y i32) (result i32)
-  local.get $x
-  local.get $y
-  i32.add)     ;; i32.sub, i32.mul, i32.div_s, i32.div_u, i32.rem_s, i32.rem_u
+(module
+  (func (param $x i32) (param $y i32) (result i32)
+    (i32.add (local.get $x) (local.get $y)))
+)
 ```
+
+Also: `i32.sub`, `i32.mul`, `i32.div_s`, `i32.div_u`, `i32.rem_s`, `i32.rem_u` and `i64.*` variants.
 
 Float arithmetic:
 
 ```wat
-(func (param $x f64) (param $y f64) (result f64)
-  local.get $x
-  local.get $y
-  f64.mul)     ;; f32.add, f32.sub, f32.mul, f32.div; f64.* variants
+(module
+  (func (param $x f64) (param $y f64) (result f64)
+    (f64.mul (local.get $x) (local.get $y)))
+)
 ```
+
+Also: `f32.add`, `f32.sub`, `f32.mul`, `f32.div` and `f64.*` variants.
 
 Bitwise and shifts (integers only):
 
 ```wat
-(func (param $x i32) (param $y i32) (result i32)
-  local.get $x
-  local.get $y
-  i32.and)     ;; i32.or, i32.xor, i32.shl, i32.shr_s, i32.shr_u, i32.rotl, i32.rotr
+(module
+  (func (param $x i32) (param $y i32) (result i32)
+    (i32.and (local.get $x) (local.get $y)))
+)
 ```
+
+Also: `i32.or`, `i32.xor`, `i32.shl`, `i32.shr_s`, `i32.shr_u`, `i32.rotl`, `i32.rotr`.
 
 ## Comparisons
 
 Comparisons push `i32` booleans (0 = false, 1 = true).
 
 ```wat
-(func (param $x i64) (param $y i64) (result i32)
-  local.get $x
-  local.get $y
-  i64.lt_s)    ;; i64.eq, i64.ne, i64.lt_s/u, i64.le_s/u, i64.gt_s/u, i64.ge_s/u
+(module
+  (func (param $x i64) (param $y i64) (result i32)
+    (i64.lt_s (local.get $x) (local.get $y)))
+)
 ```
+
+Also: `i64.eq`, `i64.ne`, `i64.le_s/u`, `i64.gt_s/u`, `i64.ge_s/u`.
 
 Floats use IEEE 754 semantics (NaN-aware):
 
 ```wat
-(func (param $x f32) (param $y f32) (result i32)
-  local.get $x
-  local.get $y
-  f32.eq)      ;; f32.ne, f32.lt, f32.le, f32.gt, f32.ge; f64.* variants
+(module
+  (func (param $x f32) (param $y f32) (result i32)
+    (f32.eq (local.get $x) (local.get $y)))
+)
 ```
+
+Also: `f32.ne`, `f32.lt`, `f32.le`, `f32.gt`, `f32.ge` and `f64.*` variants.
 
 ## Conversions
 
-Common conversions:
-
 ```wat
-(func (param $x i32) (param $y f32) (result f64)
-  local.get $x
-  f64.convert_i32_s   ;; signed i32 -> f64
-  local.get $y
-  f64.promote_f32     ;; f32 -> f64
-  f64.add)
+(module
+  (func (param $x i32) (param $y f32) (result f64)
+    (f64.add
+      (f64.convert_i32_s (local.get $x))
+      (f64.promote_f32 (local.get $y))))
+)
 ```
 
-Other families include `extend`/`wrap` between integer widths and `trunc` from floats to ints (with `_s` or `_u` variants).
+Other families: `extend`/`wrap` between integer widths, `trunc` from floats to ints (with `_s`/`_u` variants).
 
-## Control flow: block, loop, if
+## Control flow
 
 ```wat
-(func (param $n i32) (result i32)
-  (local $acc i32)
-  i32.const 0
-  local.set $acc
-  (loop $again
-    local.get $n
-    i32.eqz
-    br_if $done          ;; if n == 0 -> break to $done
-    local.get $acc
-    i32.const 1
-    i32.add
-    local.set $acc
-    local.get $n
-    i32.const 1
-    i32.sub
-    local.set $n
-    br $again
-  )
-  (block $done)
-  local.get $acc)
+(module
+  (func (param $n i32) (result i32)
+    (local $acc i32)
+    (block $done
+      (loop $again
+        (br_if $done (i32.eqz (local.get $n)))
+        (local.set $acc (i32.add (local.get $acc) (i32.const 1)))
+        (local.set $n (i32.sub (local.get $n) (i32.const 1)))
+        (br $again)))
+    (local.get $acc))
+)
 ```
 
-Notes:
-
-- `block` introduces a label you can `br`eak to (exits the block).
-- `loop` runs its body and treats `br` as a continue (jumps to top).
-- `br_if $label` pops a condition; branch if non-zero.
-
-See the spec for precise typing rules and structured control forms: [WebAssembly spec — Instructions](https://webassembly.github.io/spec/core/syntax/index.html).
+- `block` introduces a label you can `br` to (exits the block).
+- `loop` treats `br` as continue (jumps to top).
+- `br_if` pops a condition and branches if non-zero.
 
 ## Instruction Reference
 
-For complete instruction documentation with signatures and examples:
-
-- [i32 Instructions](/instructions/i32) - All 32-bit integer operations
-- [i64 Instructions](/instructions/i64) - All 64-bit integer operations
-- [f32 Instructions](/instructions/f32) - All 32-bit float operations
-- [f64 Instructions](/instructions/f64) - All 64-bit float operations
-- [Local & Global](/instructions/local-global) - `local.get`, `local.set`, `local.tee`, `global.get`, `global.set`
-- [Control Flow](/instructions/control) - `block`, `loop`, `if`, `br`, `br_if`, `call`, etc.
-
-## Practice
-
-Try small exercises (arithmetic, comparisons, control flow) in [watlings](https://github.com/EmNudge/watlings) to get the stack mental model into your fingers.
+- [i32](/instructions/i32), [i64](/instructions/i64), [f32](/instructions/f32), [f64](/instructions/f64) — all numeric operations
+- [Local & Global](/instructions/local-global) — `local.get`, `local.set`, `local.tee`, `global.get`, `global.set`
+- [Control Flow](/instructions/control) — `block`, `loop`, `if`, `br`, `br_if`, `call`, etc.

--- a/src/content/docs/ops/bitwise-shifts.md
+++ b/src/content/docs/ops/bitwise-shifts.md
@@ -8,28 +8,23 @@ Bitwise ops are for integers only.
 ```wat
 (module
   (func (export "bits") (param $x i32) (param $y i32) (result i32)
-    local.get $x
-    local.get $y
-    i32.and)                ;; i32.or, i32.xor
+    (i32.and (local.get $x) (local.get $y)))
 )
 ```
 
-Shifts/rotates:
+Also: `i32.or`, `i32.xor`.
+
+Shifts and rotates:
 
 ```wat
 (module
   (func (export "shifts") (param $x i32) (param $amt i32) (result i32)
-    local.get $x
-    local.get $amt
-    i32.shl)                ;; i32.shr_s, i32.shr_u, i32.rotl, i32.rotr
+    (i32.shl (local.get $x) (local.get $amt)))
 )
 ```
 
-Also available for `i64.*`.
+Also: `i32.shr_s`, `i32.shr_u`, `i32.rotl`, `i32.rotr` and all `i64.*` variants.
 
-Reference:
+## Instruction Reference
 
-- [i32 Instructions](/instructions/i32) - Complete i32 instruction reference
-- [i64 Instructions](/instructions/i64) - Complete i64 instruction reference
-- Spec: https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: bitwise tasks in https://github.com/EmNudge/watlings
+- [i32 Instructions](/instructions/i32), [i64 Instructions](/instructions/i64)

--- a/src/content/docs/ops/constants.md
+++ b/src/content/docs/ops/constants.md
@@ -8,27 +8,22 @@ Push literal values onto the stack.
 ```wat
 (module
   (func (export "consts") (result i32)
-    i32.const 42)             ;; i64.const, f32.const, f64.const
+    (i32.const 42))
 )
 ```
 
-Hex and floats:
+Hex and float literals:
 
 ```wat
 (module
   (func
-    i32.const 0xFF
-    drop
-    f64.const 3.14159
-    drop)
+    (drop (i32.const 0xFF))
+    (drop (f64.const 3.14159)))
 )
 ```
 
-Reference:
+Also: `i64.const`, `f32.const`.
 
-- [i32 Instructions](/instructions/i32#i32const) - `i32.const` reference
-- [i64 Instructions](/instructions/i64#i64const) - `i64.const` reference
-- [f32 Instructions](/instructions/f32#f32const) - `f32.const` reference
-- [f64 Instructions](/instructions/f64#f64const) - `f64.const` reference
-- Spec: https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: constants in https://github.com/EmNudge/watlings
+## Instruction Reference
+
+- [i32](/instructions/i32#i32const), [i64](/instructions/i64#i64const), [f32](/instructions/f32#f32const), [f64](/instructions/f64#f64const)

--- a/src/content/docs/ops/conversions.md
+++ b/src/content/docs/ops/conversions.md
@@ -3,33 +3,24 @@ title: Conversions
 description: Int/float conversions, extend/wrap, promote/demote, trunc/convert.
 ---
 
-Common conversions:
-
 ```wat
 (module
   (func (export "mix") (param $i i32) (param $f f32) (result f64)
-    local.get $i
-    f64.convert_i32_s     ;; or convert_i32_u
-    local.get $f
-    f64.promote_f32
-    f64.add)
+    (f64.add
+      (f64.convert_i32_s (local.get $i))
+      (f64.promote_f32 (local.get $f))))
 )
 ```
 
-Families:
+Conversion families:
 
-- Int width: `i64.extend_i32_s`, `i64.extend_i32_u`, `i32.wrap_i64`
-- Float width: `f64.promote_f32`, `f32.demote_f64`
-- Float→int: `i32.trunc_f32_s/u`, `i32.trunc_f64_s/u`, `i64.trunc_f32_s/u`, `i64.trunc_f64_s/u`
-- Int→float: `f32.convert_i32_s/u`, `f32.convert_i64_s/u`, `f64.convert_i32_s/u`, `f64.convert_i64_s/u`
+- **Int width**: `i64.extend_i32_s`, `i64.extend_i32_u`, `i32.wrap_i64`
+- **Float width**: `f64.promote_f32`, `f32.demote_f64`
+- **Float → int**: `i32.trunc_f32_s/u`, `i32.trunc_f64_s/u`, `i64.trunc_f32_s/u`, `i64.trunc_f64_s/u`
+- **Int → float**: `f32.convert_i32_s/u`, `f32.convert_i64_s/u`, `f64.convert_i32_s/u`, `f64.convert_i64_s/u`
 
-See also Non-trapping conversions in Extensions for saturating ops.
+See also [Non-trapping float-to-int](/extensions/nontrapping-f2i/) for saturating variants.
 
-Reference:
+## Instruction Reference
 
-- [i32 Instructions](/instructions/i32) - i32 conversions (`wrap`, `trunc`, `extend`, `reinterpret`)
-- [i64 Instructions](/instructions/i64) - i64 conversions
-- [f32 Instructions](/instructions/f32) - f32 conversions (`convert`, `demote`, `reinterpret`)
-- [f64 Instructions](/instructions/f64) - f64 conversions (`convert`, `promote`, `reinterpret`)
-- Spec: https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: conversions in https://github.com/EmNudge/watlings
+- [i32](/instructions/i32), [i64](/instructions/i64), [f32](/instructions/f32), [f64](/instructions/f64)

--- a/src/content/docs/ops/float-arithmetic.md
+++ b/src/content/docs/ops/float-arithmetic.md
@@ -3,20 +3,17 @@ title: Float Arithmetic
 description: f32/f64 add, sub, mul, div with IEEE 754 semantics.
 ---
 
+Floats follow IEEE 754: NaNs propagate and division by zero yields ±Inf (no trap).
+
 ```wat
 (module
   (func (export "fops") (param $x f64) (param $y f64) (result f64)
-    local.get $x
-    local.get $y
-    f64.mul)                ;; f32.add, f32.sub, f32.mul, f32.div; f64.* variants
+    (f64.mul (local.get $x) (local.get $y)))
 )
 ```
 
-Floats follow IEEE 754: NaNs propagate; division by zero yields ±Inf (no trap).
+Also: `f64.add`, `f64.sub`, `f64.div` and all `f32.*` variants.
 
-Reference:
+## Instruction Reference
 
-- [f32 Instructions](/instructions/f32) - Complete f32 instruction reference
-- [f64 Instructions](/instructions/f64) - Complete f64 instruction reference
-- Spec: https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: floats in https://github.com/EmNudge/watlings
+- [f32 Instructions](/instructions/f32), [f64 Instructions](/instructions/f64)

--- a/src/content/docs/ops/float-comparisons.md
+++ b/src/content/docs/ops/float-comparisons.md
@@ -3,20 +3,17 @@ title: Float Comparisons
 description: f32/f64 eq, ne, lt/le/gt/ge with NaN semantics.
 ---
 
-Float comparisons push `i32` booleans. NaN makes `eq` false and `ne` true; comparisons with NaN are false.
+Float comparisons push `i32` booleans. NaN makes `eq` false and `ne` true; all other comparisons with NaN return false.
 
 ```wat
 (module
   (func (export "fcmp") (param $x f32) (param $y f32) (result i32)
-    local.get $x
-    local.get $y
-    f32.le)                 ;; f32.eq, f32.ne, f32.lt, f32.le, f32.gt, f32.ge; f64.* variants
+    (f32.le (local.get $x) (local.get $y)))
 )
 ```
 
-Reference:
+Also: `f32.eq`, `f32.ne`, `f32.lt`, `f32.gt`, `f32.ge` and all `f64.*` variants.
 
-- [f32 Instructions](/instructions/f32) - Complete f32 instruction reference
-- [f64 Instructions](/instructions/f64) - Complete f64 instruction reference
-- Spec: https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: comparisons in https://github.com/EmNudge/watlings
+## Instruction Reference
+
+- [f32 Instructions](/instructions/f32), [f64 Instructions](/instructions/f64)

--- a/src/content/docs/ops/float-unary.md
+++ b/src/content/docs/ops/float-unary.md
@@ -6,20 +6,12 @@ description: abs, neg, sqrt, ceil, floor, trunc, nearest, min, max, copysign.
 ```wat
 (module
   (func (export "rounding") (param $x f32) (result f32)
-    local.get $x
-    f32.ceil)               ;; f32.floor, f32.trunc, f32.nearest
+    (f32.ceil (local.get $x)))
 )
 ```
 
-Other float unary ops:
+Also: `f32.floor`, `f32.trunc`, `f32.nearest`, `f32.abs`, `f32.neg`, `f32.sqrt`, `f32.min`, `f32.max`, `f32.copysign` and all `f64.*` variants.
 
-- `f32.abs`, `f32.neg`, `f32.sqrt`
-- `f32.min`, `f32.max`, `f32.copysign`
-- All available as `f64.*` too
+## Instruction Reference
 
-Reference:
-
-- [f32 Instructions](/instructions/f32) - Complete f32 instruction reference
-- [f64 Instructions](/instructions/f64) - Complete f64 instruction reference
-- Spec: https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: float ops in https://github.com/EmNudge/watlings
+- [f32 Instructions](/instructions/f32), [f64 Instructions](/instructions/f64)

--- a/src/content/docs/ops/integer-arithmetic.md
+++ b/src/content/docs/ops/integer-arithmetic.md
@@ -3,48 +3,32 @@ title: Integer Arithmetic
 description: i32/i64 add, sub, mul, div, rem and typical usage.
 ---
 
-Instructions wrap on overflow (two’s complement). Division by zero traps.
+Integer instructions wrap on overflow (two's complement). Division by zero traps.
 
 ## add, sub, mul
 
 ```wat
 (module
   (func (export "ops") (param $x i32) (param $y i32) (result i32)
-    local.get $x
-    local.get $y
-    i32.add)                 ;; i32.sub, i32.mul
+    (i32.add (local.get $x) (local.get $y)))
 )
 ```
 
+Also: `i32.sub`, `i32.mul` and all `i64.*` variants.
+
 ## div and rem
 
-Signed vs unsigned matter for negatives:
+Signed vs unsigned matters for negatives:
 
 ```wat
 (module
   (func (export "divrem") (param $x i32) (param $y i32) (result i32)
-    local.get $x
-    local.get $y
-    i32.div_s)               ;; i32.div_u for unsigned
+    (i32.div_s (local.get $x) (local.get $y)))
 )
 ```
 
-Remainder:
+Also: `i32.div_u`, `i32.rem_s`, `i32.rem_u` and `i64.*` variants.
 
-```wat
-(module
-  (func (export "rem") (param $x i32) (param $y i32) (result i32)
-    local.get $x
-    local.get $y
-    i32.rem_s)               ;; i32.rem_u
-)
-```
+## Instruction Reference
 
-Also available for `i64.*`.
-
-Reference:
-
-- [i32 Instructions](/instructions/i32) - Complete i32 instruction reference
-- [i64 Instructions](/instructions/i64) - Complete i64 instruction reference
-- Spec: https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: integers in https://github.com/EmNudge/watlings
+- [i32 Instructions](/instructions/i32), [i64 Instructions](/instructions/i64)

--- a/src/content/docs/ops/integer-comparisons.md
+++ b/src/content/docs/ops/integer-comparisons.md
@@ -8,20 +8,15 @@ Comparisons push `i32` booleans (0 = false, 1 = true).
 ```wat
 (module
   (func (export "cmp") (param $x i32) (param $y i32) (result i32)
-    local.get $x
-    local.get $y
-    i32.lt_s)               ;; i32.lt_u, i32.le_s/u, i32.gt_s/u, i32.ge_s/u, i32.eq, i32.ne
+    (i32.lt_s (local.get $x) (local.get $y)))
 )
 ```
 
-- Signed ops: `lt_s`, `le_s`, `gt_s`, `ge_s`
-- Unsigned ops: `lt_u`, `le_u`, `gt_u`, `ge_u`
-- Equality ops: `eq`, `ne`
-- 64-bit variants: `i64.*`
+- **Signed**: `lt_s`, `le_s`, `gt_s`, `ge_s`
+- **Unsigned**: `lt_u`, `le_u`, `gt_u`, `ge_u`
+- **Equality**: `eq`, `ne`
+- All available as `i64.*` variants.
 
-Reference:
+## Instruction Reference
 
-- [i32 Instructions](/instructions/i32) - Complete i32 instruction reference
-- [i64 Instructions](/instructions/i64) - Complete i64 instruction reference
-- Spec: https://webassembly.github.io/spec/core/syntax/index.html
-- Practice: comparisons in https://github.com/EmNudge/watlings
+- [i32 Instructions](/instructions/i32), [i64 Instructions](/instructions/i64)

--- a/src/content/docs/reference-types.md
+++ b/src/content/docs/reference-types.md
@@ -7,31 +7,24 @@ Reference types let Wasm refer to functions and host objects.
 
 ## Types
 
-- `funcref`: reference to a function inside the module/table.
-- `externref`: opaque reference to a host value (e.g., a JS object).
+- `funcref` — reference to a function inside the module or table.
+- `externref` — opaque reference to a host value (e.g. a JS object).
 
 ## ref.null, ref.func, ref.is_null
 
 ```wat
 (module
-  (type $t0 (func (param i32) (result i32)))
-  (func $double (type $t0) (param $x i32) (result i32)
-    local.get $x
-    i32.const 2
-    i32.mul)
+  (func $double (param $x i32) (result i32)
+    (i32.mul (local.get $x) (i32.const 2)))
 
   (table 2 funcref)
   (elem (i32.const 0) $double)
 
   (func (result i32)
-    ref.null funcref       ;; push null funcref
-    ref.is_null            ;; -> 1
-  )
+    (ref.is_null (ref.null funcref)))    ;; -> 1
 
   (func (result i32)
-    ref.func $double       ;; push a funcref to $double
-    ref.is_null            ;; -> 0
-  )
+    (ref.is_null (ref.func $double)))    ;; -> 0
 )
 ```
 
@@ -41,27 +34,24 @@ Reference types let Wasm refer to functions and host objects.
 (module
   (type $t0 (func (param i32) (result i32)))
   (func $double (type $t0) (param $x i32) (result i32)
-    local.get $x
-    i32.const 2
-    i32.mul)
+    (i32.mul (local.get $x) (i32.const 2)))
+
   (table 1 funcref)
   (elem (i32.const 0) $double)
 
   (func (param $n i32) (result i32)
-    i32.const 0
-    local.get $n
-    call_indirect (type $t0))
+    (call_indirect (type $t0) (local.get $n) (i32.const 0)))
 )
 ```
 
+The last argument to `call_indirect` is the table element index. The preceding arguments are passed to the function.
+
 ## externref
 
-From JS, you can pass host references as `externref` via imports or function parameters (supported environments only).
+From JS, you can pass host references as `externref` via imports or function parameters.
 
-References:
+## Instruction Reference
 
-- [Reference Instructions](/instructions/reference) - Complete reference for `ref.null`, `ref.func`, `ref.is_null`, `ref.as_non_null`
-- [Table Instructions](/instructions/table) - `table.get`, `table.set`, `table.grow`, `table.fill`, etc.
-- [Type Names](/instructions/types) - `funcref`, `externref`, and other reference types
-- Spec: [Reference types and tables](https://webassembly.github.io/spec/core/syntax/index.html)
-- Practice: function tables in [watlings](https://github.com/EmNudge/watlings/tree/main/exercises)
+- [Reference Instructions](/instructions/reference) — `ref.null`, `ref.func`, `ref.is_null`, `ref.as_non_null`
+- [Table Instructions](/instructions/table) — `table.get`, `table.set`, `table.grow`, `table.fill`
+- [Type Names](/instructions/types) — `funcref`, `externref`

--- a/src/content/docs/stack/drop.md
+++ b/src/content/docs/stack/drop.md
@@ -3,26 +3,18 @@ title: drop
 description: Discard the top-of-stack value.
 ---
 
-`drop` removes the top value from the stack. It’s handy when an intermediate result is not needed.
+`drop` removes the top value from the stack.
 
 ```wat
 (module
   (func (result i32)
-    i32.const 10
-    i32.const 20
-    drop           ;; drops 20
-    ;; stack: [10]
-  )
+    (drop (i32.const 20))
+    (i32.const 10))
 )
 ```
 
-Tips:
+Use `drop` to balance unwanted values — for example, when an instruction pushes a result you don't need.
 
-- Keep an eye on stack discipline. `drop` is the simplest way to balance unwanted values.
-- Combine with `block (result ...)` to ensure correct outputs from structured constructs.
+## Instruction Reference
 
-References:
-
-- [Parametric Instructions](/instructions/parametric) - Complete reference for `drop`, `select`
-- Spec: [Parametric instructions — drop](https://webassembly.github.io/spec/core/syntax/index.html)
-- Practice: stack exercises in [watlings](https://github.com/EmNudge/watlings/tree/main/exercises)
+- [Parametric Instructions](/instructions/parametric) — `drop`, `select`

--- a/src/content/docs/stack/memory-data.md
+++ b/src/content/docs/stack/memory-data.md
@@ -3,14 +3,13 @@ title: 'Memory & Data'
 description: Linear memory, loads/stores, memory size/grow, and data segments.
 ---
 
-WebAssembly exposes a contiguous byte array called linear memory. You interact with it using typed load/store instructions and can initialize it using data segments.
+WebAssembly exposes a contiguous byte array called linear memory. You interact with it via typed load/store instructions and can initialize it with data segments.
 
 ## Declaring and exporting memory
 
 ```wat
 (module
-  (memory $mem 1 4)            ;; min 1 page (64 KiB), max 4
-  (export "memory" (memory $mem))
+  (memory (export "memory") 1 4)  ;; min 1 page (64 KiB), max 4
 )
 ```
 
@@ -22,18 +21,15 @@ Typed operations read/write values at byte offsets. Narrow variants sign/zero-ex
 (module
   (memory 1)
   (func (param $ptr i32) (result i32)
-    i32.const 0x7F
-    local.get $ptr
-    i32.store8            ;; store one byte
-    local.get $ptr
-    i32.load8_u)          ;; zero-extend back to i32
+    (i32.store8 (local.get $ptr) (i32.const 0x7F))
+    (i32.load8_u (local.get $ptr)))
 )
 ```
 
 Common ops:
 
-- Loads: `i32.load`, `i64.load`, `f32.load`, `f64.load`, `i32.load8_s`, `i32.load8_u`, `i32.load16_s`, `i32.load16_u`, …
-- Stores: `i32.store`, `i64.store`, `f32.store`, `f64.store`, `i32.store8`, `i32.store16`, …
+- **Loads**: `i32.load`, `i64.load`, `f32.load`, `f64.load`, `i32.load8_s/u`, `i32.load16_s/u`, ...
+- **Stores**: `i32.store`, `i64.store`, `f32.store`, `f64.store`, `i32.store8`, `i32.store16`, ...
 
 ## memory.size and memory.grow
 
@@ -41,16 +37,13 @@ Common ops:
 (module
   (memory 1)
   (func (result i32)
-    memory.size          ;; pages
-  )
+    (memory.size))
   (func (param $pages i32) (result i32)
-    local.get $pages
-    memory.grow          ;; returns old size, or -1 on failure
-  )
+    (memory.grow (local.get $pages)))  ;; returns old size, or -1 on failure
 )
 ```
 
-If memory grows, the underlying ArrayBuffer can change; recreate typed array views on the host.
+After growth the underlying `ArrayBuffer` can change — recreate typed array views on the host.
 
 ## Data segments
 
@@ -61,14 +54,7 @@ If memory grows, the underlying ArrayBuffer can change; recreate typed array vie
 )
 ```
 
-You can use `(offset ...)` inside passive segments with bulk memory ops in advanced scenarios.
+## Instruction Reference
 
-References:
-
-- [Memory Instructions](/instructions/memory) - Complete reference for `memory.size`, `memory.grow`, `memory.fill`, `memory.copy`, etc.
-- [i32 Instructions](/instructions/i32) - `i32.load`, `i32.store` and variants
-- [i64 Instructions](/instructions/i64) - `i64.load`, `i64.store` and variants
-- [f32 Instructions](/instructions/f32) - `f32.load`, `f32.store`
-- [f64 Instructions](/instructions/f64) - `f64.load`, `f64.store`
-- Spec: [Memories and data segments](https://webassembly.github.io/spec/core/syntax/index.html)
-- Practice: memory tasks in [watlings](https://github.com/EmNudge/watlings/tree/main/exercises)
+- [Memory Instructions](/instructions/memory) — `memory.size`, `memory.grow`, `memory.fill`, `memory.copy`
+- [i32](/instructions/i32), [i64](/instructions/i64), [f32](/instructions/f32), [f64](/instructions/f64) — load/store variants

--- a/src/content/docs/stack/parametric.md
+++ b/src/content/docs/stack/parametric.md
@@ -3,7 +3,7 @@ title: Parametric Instructions
 description: 'Stack-level utilities: drop and select for branchless control.'
 ---
 
-Parametric instructions operate directly on the value stack. They’re simple but powerful for branchless logic and cleanup.
+Parametric instructions operate directly on the value stack.
 
 ## drop
 
@@ -12,39 +12,26 @@ Pop and discard the top stack value.
 ```wat
 (module
   (func (param $x i32) (result i32)
-    i32.const 123
-    drop               ;; discard
-    local.get $x       ;; the remaining value to return
-  )
+    (drop (i32.const 123))
+    (local.get $x))
 )
 ```
 
-Use cases:
-
-- Ignore an unused result (e.g., when an instruction produces an extra value).
-- Clean up the stack before producing a block result.
+Use `drop` to ignore an unused result or clean up the stack before producing a block result.
 
 ## select
 
-Choose between two values based on an `i32` condition (`0` = false):
+Choose between two values based on an `i32` condition (non-zero = first value):
 
 ```wat
 (module
   (func (param $a i32) (param $b i32) (param $cond i32) (result i32)
-    local.get $a
-    local.get $b
-    local.get $cond
-    select)
+    (select (local.get $a) (local.get $b) (local.get $cond)))
 )
 ```
 
-Notes:
+Both candidate values must have the same type.
 
-- Both candidate values must have the same type.
-- Some toolchains support typed `select` forms; consult your assembler.
+## Instruction Reference
 
-Further reading:
-
-- [Parametric Instructions](/instructions/parametric) - Complete reference for `drop`, `select`
-- Spec: [Parametric instructions](https://webassembly.github.io/spec/core/syntax/index.html)
-- Practice: related exercises in [watlings](https://github.com/EmNudge/watlings/tree/main/exercises)
+- [Parametric Instructions](/instructions/parametric) — `drop`, `select`

--- a/src/content/docs/stack/tee.md
+++ b/src/content/docs/stack/tee.md
@@ -3,42 +3,30 @@ title: local.tee
 description: Store a value into a local and keep it on the stack.
 ---
 
-`local.tee` writes to a local variable and also leaves the value on the stack for further use.
+`local.tee` writes to a local variable and leaves the value on the stack for further use.
 
 ```wat
 (module
   (func (param $x i32) (result i32)
     (local $y i32)
-    local.get $x
-    local.tee $y       ;; store into $y, keep value on stack
-    i32.const 1
-    i32.add)           ;; result = $y + 1
+    (i32.add
+      (local.tee $y (local.get $x))
+      (i32.const 1)))
 )
 ```
 
-There is no `global.tee` instruction. To set a global and keep the value on the stack, use `local.tee` into a temporary local and then `global.set`:
+There is no `global.tee`. To set a global and keep the value, use `local.tee` into a temporary then `global.set`:
 
 ```wat
 (module
   (global $g (mut i32) (i32.const 0))
   (func (param $x i32) (result i32)
     (local $tmp i32)
-    local.get $x
-    local.tee $tmp     ;; keep value on stack
-    global.set $g      ;; store copy into global $g (pops)
-    local.get $tmp     ;; push value back for further use
-    i32.const 2
-    i32.mul)
+    (global.set $g (local.tee $tmp (local.get $x)))
+    (i32.mul (local.get $tmp) (i32.const 2)))
 )
 ```
 
-Use cases:
+## Instruction Reference
 
-- Avoid repeating `local.get` when you need both to store and to continue processing.
-- Pipeline-style computations where an intermediate is also the final result.
-
-References:
-
-- [Local & Global Instructions](/instructions/local-global) - Complete reference for `local.get`, `local.set`, `local.tee`, `global.get`, `global.set`
-- Spec: [Variable instructions — tee](https://webassembly.github.io/spec/core/syntax/index.html)
-- Practice: variable ops in [watlings](https://github.com/EmNudge/watlings/tree/main/exercises)
+- [Local & Global Instructions](/instructions/local-global) — `local.get`, `local.set`, `local.tee`, `global.get`, `global.set`


### PR DESCRIPTION
Convert all 40 non-instruction-reference doc pages to use s-expression syntax where possible, fix code bugs, and trim redundant boilerplate.

- **S-expression syntax**: all code examples converted from flat stack-push style to folded form
- **Bug fixes**: loop/$done label scoping, call_indirect arg order, types.md $mix type error
- **Prose trimmed**: removed identical spec/watlings links from every page (kept on index), tightened intros
- Net reduction of ~370 lines across 40 files