### PR TITLE
Address issues #9-12: exnref types, try_table syntax, Memory64 docs, typeuse docs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -86,6 +86,7 @@ export default defineConfig({
             { label: 'Garbage Collection (WasmGC)', slug: 'extensions/wasm-gc' },
             { label: 'Multi-value', slug: 'extensions/multi-value' },
             { label: 'Import/Export Mutable Globals', slug: 'extensions/mutable-globals' },
+            { label: 'Memory64', slug: 'extensions/memory64' },
             { label: 'Reference Types', slug: 'extensions/reference-types' },
             { label: 'Non-trapping Float→Int', slug: 'extensions/nontrapping-f2i' },
             { label: 'Sign-extension Ops', slug: 'extensions/sign-extension' },

--- a/instructions.md
+++ b/instructions.md
@@ -3031,7 +3031,7 @@ Declares a WebAssembly module. Top-level container for all declarations.
 
 Example:
 
-```wat
+```wat-snippet
 (module $my_module
   ;; Module contents here
   (func ...)
@@ -3224,7 +3224,7 @@ Declares a function to be called automatically when the module is instantiated.
 
 Example:
 
-```wat
+```wat-snippet
 (module
   (func $init
     ;; Initialization code here
@@ -3241,6 +3241,14 @@ Example:
 ## type
 
 Declares a function type that can be referenced elsewhere.
+
+A **typeuse** is a reference to a function type that can appear in `func`, `call_indirect`, `return_call_indirect`, and block types. It can be written three ways:
+
+- **Explicit type reference only** — params/results come from the referenced type
+- **Inline params/results only** — a matching type is implicitly created or reused
+- **Both** — the inline params/results must match the referenced type
+
+Form 3 is useful when you need both a type index (for `call_indirect`) and named parameters.
 
 Example:
 
@@ -3648,6 +3656,35 @@ Example:
 
 ```wat
 (global $no_extern nullexternref (ref.null noextern))
+```
+
+---
+
+## exnref
+
+Reference type for exception objects (exception handling proposal). Equivalent to `(ref null exn)`.
+
+Example:
+
+```wat
+(block $handler (result exnref)
+  (try_table (catch_all_ref $handler)
+    (call $may_throw)
+    (unreachable)
+  )
+)
+```
+
+---
+
+## nullexnref
+
+Null reference type for exceptions (exception handling proposal). Equivalent to `(ref null noexn)`.
+
+Example:
+
+```wat
+(global $no_exn nullexnref (ref.null noexn))
 ```
 
 ---

--- a/src/content/docs/extensions/exception-handling.md
+++ b/src/content/docs/extensions/exception-handling.md
@@ -1,26 +1,26 @@
 ---
 title: 'Exception Handling'
-description: 'Try/catch/throw for native exception support in Wasm.'
+description: 'try_table/throw for native exception support in Wasm.'
 ---
 
-Exception handling introduces `try`, `catch`, `throw`, and related constructs for structured error handling.
+Exception handling introduces `try_table`, `throw`, and related constructs for structured error handling.
 
 ```wat
 (module
   (tag $e (param i32))
 
   (func (export "mayThrow") (param $x i32) (result i32)
-    (try (result i32)
-      (do
+    (block $handler (result i32)
+      (try_table (catch $e $handler)
         (if (i32.eqz (local.get $x))
           (then (throw $e (i32.const 1))))
-        (i32.const 0))
-      (catch $e
-        (drop)
-        (i32.const -1))))
+        (i32.const 0)
+      )
+    )
+  )
 )
 ```
 
 ## Instruction Reference
 
-- [Exception Instructions](/instructions/exceptions) — `throw`, `throw_ref`, `rethrow`, `tag`, `try_table`, `catch`, `catch_all`
+- [Exception Instructions](/instructions/exceptions) — `throw`, `throw_ref`, `tag`, `try_table`, `catch`, `catch_all`

--- a/src/content/docs/extensions/memory64.md
+++ b/src/content/docs/extensions/memory64.md
@@ -1,0 +1,31 @@
+---
+title: 'Memory64'
+description: '64-bit memory and table addressing for large linear memories.'
+---
+
+Memory64 allows memories and tables to use `i64` indices instead of `i32`, expanding the addressable space from 4 GiB to 16 EiB.
+
+```wat-snippet
+(module
+  ;; 64-bit addressed memory (1 page minimum)
+  (memory $mem i64 1)
+
+  (func (export "load64") (param $addr i64) (result i32)
+    (i32.load (local.get $addr)))
+
+  (func (export "size") (result i64)
+    (memory.size))
+)
+```
+
+When used with an `i64`-addressed memory:
+
+- Memory instructions (`i32.load`, `i64.store`, etc.) accept `i64` addresses
+- `memory.size` and `memory.grow` return and accept `i64` values
+- Bulk memory operations (`memory.copy`, `memory.fill`, `memory.init`) use `i64` for addresses and lengths
+- Tables also support `i64` indexing: `(table $tbl i64 10 funcref)`
+
+## Instruction Reference
+
+- [Memory Instructions](/instructions/memory) — `i32.load`, `i32.store`, `memory.size`, `memory.grow`, `memory.copy`, `memory.fill`
+- [Table Instructions](/instructions/table) — `table.get`, `table.set`, `table.size`, `table.grow`

--- a/src/content/docs/instructions/module.md
+++ b/src/content/docs/instructions/module.md
@@ -220,6 +220,14 @@ Declares a function to be called automatically when the module is instantiated.
 
 Declares a function type that can be referenced elsewhere.
 
+A **typeuse** is a reference to a function type that can appear in `func`, `call_indirect`, `return_call_indirect`, and block types. It can be written three ways:
+
+- **Explicit type reference only** — params/results come from the referenced type
+- **Inline params/results only** — a matching type is implicitly created or reused
+- **Both** — the inline params/results must match the referenced type
+
+Form 3 is useful when you need both a type index (for `call_indirect`) and named parameters.
+
 **Example:**
 
 ```wat

--- a/src/content/docs/instructions/types.md
+++ b/src/content/docs/instructions/types.md
@@ -270,6 +270,35 @@ Null reference type for external values (GC proposal). Equivalent to `(ref null 
 
 ---
 
+## exnref
+
+Reference type for exception objects (exception handling proposal). Equivalent to `(ref null exn)`.
+
+**Example:**
+
+```wat
+(block $handler (result exnref)
+  (try_table (catch_all_ref $handler)
+    (call $may_throw)
+    (unreachable)
+  )
+)
+```
+
+---
+
+## nullexnref
+
+Null reference type for exceptions (exception handling proposal). Equivalent to `(ref null noexn)`.
+
+**Example:**
+
+```wat
+(global $no_exn nullexnref (ref.null noexn))
+```
+
+---
+
 ## i8
 
 8-bit integer storage type for packed struct fields and arrays (GC proposal). Not a value type - values are widened to i32 when accessed.


### PR DESCRIPTION
## Summary

Addresses all 4 open issues:

- **#9**: Add `exnref` and `nullexnref` to type names reference
- **#10**: Update exception handling extension page to use `try_table` syntax
- **#11**: Document Memory64 extension (new page + sidebar entry)
- **#12**: Document typeuse abbreviation mechanism

Also improves the instruction doc generator to support `wat-snippet` code blocks and multi-line descriptions.